### PR TITLE
Remove useless log4j-core and load slf4j log implementation only on test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.32</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Thank you for the great project !

I found that the source code of the project and dep docx4j-JAXB-ReferenceImpl are based on slf4j, not log4j.

![image](https://user-images.githubusercontent.com/18087875/145749558-f8c01338-3577-4a56-80b2-7c853ddda815.png)

Therefore, we should remove the log4j dependency and only load the slf4j log implementation in the test scope.

And, this also fixes the error in test
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
```

